### PR TITLE
refactor: stops event flash when using `fetchEvents` method

### DIFF
--- a/resources/views/fullcalendar.blade.php
+++ b/resources/views/fullcalendar.blade.php
@@ -79,11 +79,11 @@
                     calendar.render();
 
                     window.addEventListener("filament-fullcalendar:refresh", () => {
-                        calendar.removeAllEvents();
-                        
                         @if( $this::canFetchEvents() )
                             calendar.refetchEvents();
                         @else
+                            calendar.removeAllEvents();
+
                             event.detail.data.map(event => calendar.addEvent(event));
                         @endif
                     });


### PR DESCRIPTION
Since it is recommended to only use one of the methods `fetchEvents` or `getViewData`, we only need to remove all events when using `getViewData` as the Fullcalendar method `calendar.refetchEvents` will fetch the events and rerender them in the background without causing the events to flash.

[Fullcalendar refetchEvents docs](https://fullcalendar.io/docs/Calendar-refetchEvents)